### PR TITLE
Fix an issue with NPCs with missing sense data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Changelog
+
+## 1.0.2 - 2022-05-06
+- Fix an issue with NPCs with missing sense data
+
 ## 1.0.1 - 2022-03-16
 - Fix greater darkvision not providing vision in areas of darkness.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FVTT-PF2e-Rule-Based-NPC-Vision
+# FVTT PF2e Rule-Based NPC Vision
 A module for the Foundry VTT PF2e system which enables rules-based vision for NPCs.
 
 ## Features

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "PF2e Rules-Based NPC Vision",
     "description": "Enable PF2e rules-based vision for NPCs.",
     "author": "JDCalvert",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "minimumCoreVersion": "9",
     "compatibleCoreVersion": "9",
     "system": [
@@ -16,7 +16,7 @@
     ],
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Rules-Based-NPC-Vision",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Rules-Based-NPC-Vision/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Rules-Based-NPC-Vision/archive/1.0.1.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Rules-Based-NPC-Vision/archive/1.0.2.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Rules-Based-NPC-Vision",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Rules-Based-NPC-Vision/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Rules-Based-NPC-Vision/blob/main/CHANGELOG.md",

--- a/scripts/npcvision.js
+++ b/scripts/npcvision.js
@@ -16,8 +16,8 @@ Hooks.on(
         libWrapper.register(
             pf2eRulesBasedNpcVisionModuleName,
             "CONFIG.PF2E.Actor.documentClasses.npc.prototype.visionLevel",
-            function npcVisionLevel(...args) {
-                const senses = this.data.data.traits.senses.value.split(",").map(s => s.replace(/[\s-]+/g, '').toLowerCase());
+            function npcVisionLevel() {
+                const senses = (this.data.data.traits.senses.value ?? "").split(",").map(s => s.replace(/[\s-]+/g, '').toLowerCase());
                 return this.getCondition("blinded") ? VisionLevelPF2e.BLINDED
                     : senses.some(sense => ["darkvision", "greaterdarkvision"].includes(sense))
                         ? VisionLevelPF2e.DARKVISION


### PR DESCRIPTION
Fixed an issue where an NPCs sense value being `undefined` would cause an error preventing the canvas from rendering.